### PR TITLE
absorptionCoefficient_Generic: allow initialization of Xsect with other datatype than float

### DIFF
--- a/hapi/hapi.py
+++ b/hapi/hapi.py
@@ -35376,7 +35376,7 @@ def absorptionCoefficient_Generic(Components=None,SourceTables=None,partitionFun
                                   WavenumberWingHW=None,WavenumberGrid=None,
                                   Diluent={},LineMixingRosen=False,
                                   profile=None,calcpars=None,exclude=set(),
-                                  DEBUG=None):
+                                  DEBUG=None, initial_Xsect=None):
                                                               
     # Throw exception if profile or calcpars are empty.
     if profile is None: raise Exception('user must provide the line profile function')
@@ -35423,7 +35423,7 @@ def absorptionCoefficient_Generic(Components=None,SourceTables=None,partitionFun
         #Omegas = arange(OmegaRange[0],OmegaRange[1],OmegaStep)
         Omegas = arange_(OmegaRange[0],OmegaRange[1],OmegaStep) # fix
     number_of_points = len(Omegas)
-    Xsect = zeros(number_of_points)
+    Xsect = zeros(number_of_points) if initial_Xsect is None else initial_Xsect
        
     # reference temperature and pressure
     T_ref_default = __FloatType__(296.) # K


### PR DESCRIPTION
The profile=... argument of absorptionCoefficient_Generic in principle allows to supply custom line profiles. We would like to use that for complex-valued profiles, so that the phase upon transmission through a medium can also be calculated - however, this won't work currently because of the line

  Xsect = zeros(number_of_points) 

where Xsect is initialized as real-valued type. An easy fix would be to allow to initialize Xsect with an optional keyword argument, like suggested in this pull request.

This would allow the user to initialize Xsect manually and thus permit several additional use cases:

- returning complex crosssections
- in-place addition of a new molecule to an existing crossection spectrum
- initialize Xsect with a Python class that fakes to be a numpy array, but records the data of each individual line separately (which we also plan to use so that we can directly synthesize impulse responses in the time domain) 